### PR TITLE
Allow for event deletion

### DIFF
--- a/ICS-ICAL Sync/Code.gs
+++ b/ICS-ICAL Sync/Code.gs
@@ -9,22 +9,16 @@
 
 // --------------- SETTINGS ---------------
 
-// var sourceCalendars = { targetCalendarName:"sourceCalendarURL"}
-//     "targetCalendarName" is The name of the Google Calendar you want to add events to
-//     "sourceCalendarURL" is The ics/ical url that you want to get events from
-
-var sourceCalendars={
-  example:""
-};
+var targetCalendarName = "" // The name of the Google Calendar you want to add events to
+var sourceCalendarURL = "" // The ics/ical url that you want to get events from
 
 
 // Currently global settings are applied to all sourceCalendars.  
 
-var howFrequent = 20; //What interval (minutes) to run this script on to check for new events
+var howFrequent = 60; //What interval (minutes) to run this script on to check for new events
 var addEventsToCalendar = true; //If you turn this to "false", you can check the log (View > Logs) to make sure your events are being read correctly before turning this on
 var modifyExistingEvents = true; // If you turn this to "false", any event in the feed that was modified after being added to the calendar will not update
 var removeEventsFromCalendar = true; //If you turn this to "true", any event in the calendar not found in the feed will be removed.  
-var createMissingCalendar=true;  // If the calendar name is not found we create it instead of throwing an error, only if the sourceUrl works.
 var addAlerts = true; //Whether to add the ics/ical alerts as notifications on the Google Calendar events
 var descriptionAsTitles = false; //Whether to use the ics/ical descriptions as titles (true) or to use the normal titles as titles (false)
 var defaultDuration = 30; //Default duration (in minutes) in case the event is missing an end specification in the ICS/ICAL file
@@ -61,13 +55,6 @@ function Install(){
 
 function main(){
   
-  for( var calendar in sourceCalendars){
-    Logger.log("Syncing "+ calendar);
-    syncCalendar(calendar, sourceCalendars[calendar]);
-  }
-}
-
-function syncCalendar(targetCalendarName, sourceCalendarURL) {  
   //Get URL items
   var response = UrlFetchApp.fetch(sourceCalendarURL);
   response = response.getContentText().split("\r\n");
@@ -83,12 +70,8 @@ function syncCalendar(targetCalendarName, sourceCalendarURL) {
     throw "[ERROR] Incorrect ics/ical URL";
   
   if(targetCalendar == null){
-    if(createMissingCalendar){
       Logger.log("Creating Calendar: "+targetCalendarName);
       targetCalendar = CalendarApp.createCalendar(targetCalendarName);
-    }else{
-      throw "[ERROR] Could not find calendar of name \"" + targetCalendarName + "\"";
-    }
   }
   
   if (emailWhenAdded && email == "")
@@ -156,18 +139,18 @@ function syncCalendar(targetCalendarName, sourceCalendarURL) {
   
   //------------------------ Check results -------------------------
   Logger.log("# of events: " + events.length);
-//  for (var i = 0; i < events.length; i++){
-//    Logger.log("Title: " + events[i].title);
-//    Logger.log("Id: " + events[i].id);
-//    Logger.log("Description: " + events[i].description);
-//    Logger.log("Start: " + events[i].startTime);
-//    Logger.log("End: " + events[i].endTime);
-//    
-//    for (var j = 0; j < events[i].reminderTimes.length; j++)
-//      Logger.log("Reminder: " + events[i].reminderTimes[j] + " seconds before");
-//    
-//    Logger.log("");
-//  }
+  for (var i = 0; i < events.length; i++){
+    Logger.log("Title: " + events[i].title);
+    Logger.log("Id: " + events[i].id);
+    Logger.log("Description: " + events[i].description);
+    Logger.log("Start: " + events[i].startTime);
+    Logger.log("End: " + events[i].endTime);
+    
+    for (var j = 0; j < events[i].reminderTimes.length; j++)
+      Logger.log("Reminder: " + events[i].reminderTimes[j] + " seconds before");
+    
+    Logger.log("");
+  }
   //----------------------------------------------------------------
   
   if(addEventsToCalendar || removeEventsFromCalendar){

--- a/ICS-ICAL Sync/Code.gs
+++ b/ICS-ICAL Sync/Code.gs
@@ -20,13 +20,14 @@ var sourceCalendars={
 
 // Currently global settings are applied to all sourceCalendars.  
 
-var howFrequent = 1; //What interval (minutes) to run this script on to check for new events
+var howFrequent = 20; //What interval (minutes) to run this script on to check for new events
 var addEventsToCalendar = true; //If you turn this to "false", you can check the log (View > Logs) to make sure your events are being read correctly before turning this on
+var modifyExistingEvents = true; // If you turn this to "false", any event in the feed that was modified after being added to the calendar will not update
 var removeEventsFromCalendar = true; //If you turn this to "true", any event in the calendar not found in the feed will be removed.  
 var createMissingCalendar=true;  // If the calendar name is not found we create it instead of throwing an error, only if the sourceUrl works.
 var addAlerts = true; //Whether to add the ics/ical alerts as notifications on the Google Calendar events
 var descriptionAsTitles = false; //Whether to use the ics/ical descriptions as titles (true) or to use the normal titles as titles (false)
-var defaultDuration = 60; //Default duration (in minutes) in case the event is missing an end specification in the ICS/ICAL file
+var defaultDuration = 30; //Default duration (in minutes) in case the event is missing an end specification in the ICS/ICAL file
 
 var emailWhenAdded = false; //Will email you when an event is added to your calendar
 var email = ""; //OPTIONAL: If "emailWhenAdded" is set to true, you will need to provide your email
@@ -200,20 +201,46 @@ function syncCalendar(targetCalendarName, sourceCalendarURL) {
   //----------------------------------------------------------------
   
   
-  //----------------------- Remove events from calendar ------------
-  if(removeEventsFromCalendar){
-    Logger.log("Checking "+calendarEvents.length+" Events For Removal");
-
-    for(var i=0; i < calendarEvents.length; i++){
-      if( feedEventIds.indexOf( calendarEvents[i].getTag("FID") ) == -1  ){
+  
+  //-------------- Remove Or modify events from calendar -----------
+  for(var i=0; i < calendarEvents.length; i++){
+    Logger.log("Checking "+calendarEvents.length+" Events For Removal or Modification");
+    var feedIndex = feedEventIds.indexOf( calendarEvents[i].getTag("FID") );
+    if(removeEventsFromCalendar){
+      if( feedIndex  == -1  ){
         Logger.log("    Deleting "+calendarEvents[i].getTitle());
         calendarEvents[i].deleteEvent();
       }
     }
+    
+    if(modifyExistingEvents){
+      if( feedIndex != -1  ){
+        var e = calendarEvents[i];
+
+        var fes = events.filter(sameEvent, calendarEvents[i].getTag("FID"));
+        if( fes.length > 0){
+          
+          var fe = fes[0];
+          
+          if(e.getStartTime() != fe.startTime || e.getEndTime() != fe.endTime)
+            e.setTime(fe.startTime, fe.endTime)
+          if(e.getTitle() != fe.title)
+            e.setTitle(fe.title);
+          if(e.getLocation() != fe.location)
+            e.setLocation(fe.location)
+          if(e.getDescription() != fe.description)
+            e.setDescription(fe.description)
+          
+                    
+        }
+      }
+    } 
   }
   //----------------------------------------------------------------
   
 }
+
+
 
 function ParseNotificationTime(notificationString){
   //https://www.kanzaki.com/docs/ical/duration-t.html
@@ -253,6 +280,10 @@ function ParseNotificationTime(notificationString){
   }
 }
 
+
+function sameEvent(x){
+  return x.id == this;
+}
 //function EventExists(calendar, event){
 //  
 //  var events = calendar.getEvents(event.startTime, event.endTime, {search : event.id});

--- a/ICS-ICAL Sync/Code.gs
+++ b/ICS-ICAL Sync/Code.gs
@@ -15,13 +15,13 @@ var sourceCalendarURL = "" // The ics/ical url that you want to get events from
 
 // Currently global settings are applied to all sourceCalendars.  
 
-var howFrequent = 60; //What interval (minutes) to run this script on to check for new events
+var howFrequent = 15; //What interval (minutes) to run this script on to check for new events
 var addEventsToCalendar = true; //If you turn this to "false", you can check the log (View > Logs) to make sure your events are being read correctly before turning this on
 var modifyExistingEvents = true; // If you turn this to "false", any event in the feed that was modified after being added to the calendar will not update
 var removeEventsFromCalendar = true; //If you turn this to "true", any event in the calendar not found in the feed will be removed.  
 var addAlerts = true; //Whether to add the ics/ical alerts as notifications on the Google Calendar events
 var descriptionAsTitles = false; //Whether to use the ics/ical descriptions as titles (true) or to use the normal titles as titles (false)
-var defaultDuration = 30; //Default duration (in minutes) in case the event is missing an end specification in the ICS/ICAL file
+var defaultDuration = 60; //Default duration (in minutes) in case the event is missing an end specification in the ICS/ICAL file
 
 var emailWhenAdded = false; //Will email you when an event is added to your calendar
 var email = ""; //OPTIONAL: If "emailWhenAdded" is set to true, you will need to provide your email


### PR DESCRIPTION
Multiple calendars can be added to the sourceCalendars global.

Events found in a users calendar not found in a feed during a sync can be removed, controlled by global flag.

Events no longer store feed ids in the description and use a custom "FID" metadata tag.

Event matching is based on this "FID" tag.